### PR TITLE
Fix incorrect import (and related crash)

### DIFF
--- a/papis_rofi/main.py
+++ b/papis_rofi/main.py
@@ -148,7 +148,7 @@ class Gui(object):
         header_format = papis.config.get("header-format", section="rofi-gui")
 
         def header_filter(x):
-            if isinstance(x, papis.format.Document) or isinstance(x, dict):
+            if isinstance(x, papis.document.Document) or isinstance(x, dict):
                 return papis.format.format(header_format, x)
             else:
                 return x


### PR DESCRIPTION
Fixes #11 .

This makes papis-rofi work on both latest released version (0.13) and against current main branch. 