### PR TITLE
Removed the `None` return in main gui function

### DIFF
--- a/papis_rofi/main.py
+++ b/papis_rofi/main.py
@@ -194,6 +194,10 @@ class Gui(object):
             elif key == self.query_key:
                 self.query_string = self.window.text_entry("Query input: ")
                 self.set_docs_from_query()
+        else:
+            # If esc or alt-q key pressed, select no documents
+            # Papis does not support NoneType returns here.
+            return []
 
     def delete(self, doc):
         answer = self.window.text_entry(


### PR DESCRIPTION
Replace with `[]` return for "no document selected", to avoid crash on papis side.

The error used to be :

```python
Traceback (most recent call last):
  File /home/<myusername>/.local/bin/papis, line 8, in <module>
    sys.exit(run())
  File /usr/lib/python3/dist-packages/click/core.py, line 1128, in __call__
    return self.main(*args, **kwargs)
  File /usr/lib/python3/dist-packages/click/core.py, line 1053, in main
    rv = self.invoke(ctx)
  File /usr/lib/python3/dist-packages/click/core.py, line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File /usr/lib/python3/dist-packages/click/core.py, line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File /usr/lib/python3/dist-packages/click/core.py, line 754, in invoke
    return __callback(*args, **kwargs)
  File /home/<myusername>/.local/lib/python3.10/site-packages/papis/commands/edit.py, line 101, in cli
    documents = papis.cli.handle_doc_folder_query_all_sort(query,
  File /home/<myusername>/.local/lib/python3.10/site-packages/papis/cli.py, line 162, in handle_doc_folder_query_all_sort
    documents = [doc for doc in papis.pick.pick_doc(documents) if doc]
TypeError: 'NoneType' object is not iterable
```